### PR TITLE
Add explicit Compat dependency for readstring

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Requests
 DataFrames
 JSON
 HttpCommon
+Compat 0.7.9

--- a/src/BlsData.jl
+++ b/src/BlsData.jl
@@ -6,6 +6,7 @@ using Requests
 using DataFrames
 import JSON
 import HttpCommon
+using Compat
 
 export 
     # Bls type


### PR DESCRIPTION
currently you're getting lucky that some of your dependencies happen
to be importing Compat, which results in readstring being defined on 0.4

if any of the dependencies ever had a version that didn't depend on Compat,
then readstring wouldn't be defined on julia 0.4 - unless you import Compat
yourself