### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 julia:
   - 0.4
   - 0.5
-  - release
+  - 0.6
 matrix:
     allow_failures:
         - julia: nightly


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested